### PR TITLE
LPS-52537 Article should be viewed if its in Pending status

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
+++ b/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
@@ -19,7 +19,7 @@
 <%
 KBArticle kbArticle = (KBArticle)request.getAttribute(WebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-if (enableKBArticleViewCountIncrement && !kbArticle.isDraft()) {
+if (enableKBArticleViewCountIncrement && !kbArticle.isDraft() && !kbArticle.isPending()) {
 	KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
 
 	KBArticleLocalServiceUtil.updateViewCount(themeDisplay.getUserId(), kbArticle.getResourcePrimKey(), latestKBArticle.getViewCount() + 1);


### PR DESCRIPTION
This issue was caused by the status of an article.When the status of an article is Pending, it throws Exception while clicking it.
The root cause is that whenever the status is pending code below code tries to fetch data from database with status APPROVED :

KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);

So above code shouldn't be executed if status is pending, so as solution i have added !kbArticle.isPending() as validation, as it would not allow to execute above code if status is pending.