### PR TITLE
LPS-52537 Article should be viewed if its in Pending status

### DIFF
--- a/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/model/impl/KBArticleImpl.java
+++ b/portlets/knowledge-base-portlet/docroot/WEB-INF/src/com/liferay/knowledgebase/model/impl/KBArticleImpl.java
@@ -96,7 +96,7 @@ public class KBArticleImpl extends KBArticleBaseImpl {
 
 	@Override
 	public long getClassPK() {
-		if (isApproved()) {
+		if (isApproved() || isPending()) {
 			return getResourcePrimKey();
 		}
 

--- a/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
+++ b/portlets/knowledge-base-portlet/docroot/admin/common/view_article.jsp
@@ -19,7 +19,7 @@
 <%
 KBArticle kbArticle = (KBArticle)request.getAttribute(WebKeys.KNOWLEDGE_BASE_KB_ARTICLE);
 
-if (enableKBArticleViewCountIncrement && !kbArticle.isDraft()) {
+if (enableKBArticleViewCountIncrement && !kbArticle.isDraft() && !kbArticle.isPending()) {
 	KBArticle latestKBArticle = KBArticleLocalServiceUtil.getLatestKBArticle(kbArticle.getResourcePrimKey(), WorkflowConstants.STATUS_APPROVED);
 
 	KBArticleLocalServiceUtil.updateViewCount(themeDisplay.getUserId(), kbArticle.getResourcePrimKey(), latestKBArticle.getViewCount() + 1);


### PR DESCRIPTION
This commit contains 2 file changes.
The issue was caused by calling APPROVE STATUS method even if status is pending and returning articleId instead of resourcePrimKey.
Which is being resolved.

