### PR TITLE
Lps 55203 master

### DIFF
--- a/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/hook/upgrade/v1_0_0/UpgradeCalendarBooking.java
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/hook/upgrade/v1_0_0/UpgradeCalendarBooking.java
@@ -15,6 +15,7 @@
 package com.liferay.calendar.hook.upgrade.v1_0_0;
 
 import com.liferay.calendar.hook.upgrade.v1_0_0.util.CalendarBookingTable;
+import com.liferay.calendar.util.PortletPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 import java.sql.SQLException;
@@ -26,6 +27,8 @@ public class UpgradeCalendarBooking extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {
+		PortletPropsValues.CALENDAR_SYNC_CALEVENTS_ON_STARTUP = true;
+
 		try {
 			runSQL("alter_column_type CalendarBooking description TEXT null");
 		}

--- a/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/service/impl/CalendarImporterLocalServiceImpl.java
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/service/impl/CalendarImporterLocalServiceImpl.java
@@ -145,6 +145,8 @@ public class CalendarImporterLocalServiceImpl
 			classNameLocalService.getClassNameId(
 				CalendarBooking.class.getName()),
 			calendarBookingId);
+
+		CalEventLocalServiceUtil.deleteCalEvent(calEvent);
 	}
 
 	@Override

--- a/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/util/PortletPropsValues.java
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/com/liferay/calendar/util/PortletPropsValues.java
@@ -46,7 +46,7 @@ public class PortletPropsValues {
 			PortletProps.get(
 				PortletPropsKeys.CALENDAR_RESOURCE_FORCE_AUTOGENERATE_CODE));
 
-	public static final boolean CALENDAR_SYNC_CALEVENTS_ON_STARTUP =
+	public static boolean CALENDAR_SYNC_CALEVENTS_ON_STARTUP =
 		GetterUtil.getBoolean(
 			PortletProps.get(
 				PortletPropsKeys.CALENDAR_SYNC_CALEVENTS_ON_STARTUP));

--- a/portlets/calendar-portlet/docroot/WEB-INF/src/portlet.properties
+++ b/portlets/calendar-portlet/docroot/WEB-INF/src/portlet.properties
@@ -39,6 +39,6 @@ calendar.resource.force.autogenerate.code=true
 
 calendar.rss.template=dependencies/rss/booking_entry.tmpl
 
-calendar.sync.calevents.on.startup=true
+calendar.sync.calevents.on.startup=false
 
 resource.actions.configs=resource-actions/default.xml


### PR DESCRIPTION
The Calendar booking importer only needs to run once when the portlet upgrades. If after an upgrade a site/user is deleted that has any events in the calEvent table, there will be errors in the log on every restart. We cannot move the import to the upgrade process as it requires services which are not available during the upgrade process. This fix will change the behavior so the syncing of calEvents only occurs once, or unless specifically specified in the portlet-ext.properties.